### PR TITLE
fix: handle Jira webhook responses robustly (accept 2xx, surface failures as warnings)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,28 +1,66 @@
 #!python3
 
-import sys
-import requests
 import os
-import json
+import sys
+
+import requests
+
+WEBHOOK_URL = os.environ.get("INPUT_WEBHOOK-URL")
+PROJECT = os.environ.get("INPUT_PROJECT") or ""
+RELEASE = os.environ.get("INPUT_RELEASE") or ""
+TICKETS = [t for t in (os.environ.get("INPUT_TICKETS") or "").split(" ") if t]
+
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def warn(message):
+    # GitHub Actions warning annotation: visible in the run summary/UI
+    # without failing the job.
+    print("::warning title=Jira release::{0}".format(message))
+
+
+# Nothing to send: a release with no tickets is normal (e.g. infra-only
+# releases). Pass so the deploy report isn't affected.
+if not TICKETS:
+    print("No Jira tickets in this release; nothing to send. Skipping.")
+    sys.exit(0)
+
+if not WEBHOOK_URL:
+    warn("INPUT_WEBHOOK-URL is empty; cannot notify Jira. Skipping.")
+    sys.exit(0)
+
+payload = {
+    "release": {"tag_name": "{0}-{1}".format(PROJECT, RELEASE)},
+    "issues": TICKETS,
+}
 
 try:
-    payload = {
-        'release': {
-            'tag_name': "{0}-{1}".format(
-                os.environ.get('INPUT_PROJECT'),
-                os.environ.get('INPUT_RELEASE')
-            )
-        },
-        'issues': list(os.environ.get('INPUT_TICKETS').split(' '))
-    }
-    r = requests.post(
-        url=os.environ.get('INPUT_WEBHOOK-URL'),
-        headers={'Content-Type': 'application/json'},
-        json=payload)
-    print("SUCCESS")
+    response = requests.post(
+        url=WEBHOOK_URL,
+        headers={"Content-Type": "application/json"},
+        json=payload,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+except requests.RequestException as error:
+    # A Jira hiccup must never fail an already-completed deploy; surface it
+    # loudly instead of silently passing.
+    warn("Request to the Jira webhook failed: {0}".format(error))
     sys.exit(0)
-except Exception as e:
-    # If there are no tickets in the release,
-    # auto-pass regardless so as not to effect the deploy report.
-    print("SUCCESS")
+
+# Jira Automation incoming webhooks return 202 Accepted, so accept any 2xx.
+if 200 <= response.status_code < 300:
+    print(
+        "SUCCESS: Jira webhook accepted release {0}-{1} ({2})".format(
+            PROJECT, RELEASE, response.status_code
+        )
+    )
     sys.exit(0)
+
+# Non-2xx: make it obvious (this is how the stale JIRA_WEBHOOK_NEW_RELEASE
+# secret would show up), but don't block the release job.
+body = (response.text or "").strip()[:500]
+warn(
+    "Jira webhook returned {0}; release notes may not have been created. "
+    "Response: {1}".format(response.status_code, body)
+)
+sys.exit(0)

--- a/main.py
+++ b/main.py
@@ -15,8 +15,16 @@ REQUEST_TIMEOUT_SECONDS = 30
 
 def warn(message):
     # GitHub Actions warning annotation: visible in the run summary/UI
-    # without failing the job.
-    print("::warning title=Jira release::{0}".format(message))
+    # without failing the job. Workflow commands are single-line, so encode
+    # control chars (a multi-line body such as an HTML 404 page would
+    # otherwise break the annotation and drop the message). Encode '%' first.
+    safe = (
+        str(message)
+        .replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+    print("::warning title=Jira release::{0}".format(safe))
 
 
 # Nothing to send: a release with no tickets is normal (e.g. infra-only


### PR DESCRIPTION
## Problem

Surfaced while cutting **choam v2.0.0** (a major release whose commit range finally exercised this action). The `Create JIRA Release` step failed with `ERROR: 404 <Response [404]>` and failed the whole `release` job (after stg+prd had already deployed).

Two versions of this action exist, and **both are wrong in opposite directions**:

- **`v2.0.0` (`daa4dd1`, which consumers pin):** treats only HTTP `200` as success and `sys.exit(-1)` on anything else. But **Jira Automation incoming webhooks return `202 Accepted`**, so even a *successful* call would fail — and any hiccup hard-fails the release job.
- **current `main`:** wraps the POST in a bare `try/except` and **always prints `SUCCESS` / exits `0`**, ignoring the status code entirely. This hides genuinely broken webhooks (e.g. a stale `JIRA_WEBHOOK_NEW_RELEASE` secret) — the failure is silently swallowed forever.

## Change

Make the status handling correct and observable without ever blocking a completed deploy:

- **Accept any `2xx`** as success (so `202` from Jira Automation works).
- **Add a 30s request timeout** (no hanging jobs).
- **Guard empty/missing `tickets` and `webhook-url`** instead of crashing on `.split()` / `None`.
- On request errors or non-`2xx`, emit a GitHub Actions **`::warning::` annotation** with the status code and response body, then **exit `0`**. A broken webhook is now *loud* in the run summary, but a Jira hiccup never fails an already-successful release.

## Behavior matrix

| Scenario | v2.0.0 | current main | this PR |
|---|---|---|---|
| Webhook returns 202 | ❌ fail job | ✅ pass (blind) | ✅ pass (logged) |
| Webhook returns 404 (stale secret) | ❌ fail job | ✅ pass (silent) | ⚠️ warn, pass |
| No tickets in release | passes | passes | passes (explicit skip) |
| Network error/timeout | ❌ fail job | ✅ pass (silent) | ⚠️ warn, pass |

## Test plan

- [x] `python3 -m py_compile main.py`
- [ ] Cut a test release (or re-run choam's `release` job) once merged + a new tag is published, and confirm a valid webhook logs `SUCCESS (202)` and a bad URL logs a `::warning::` without failing the job.

## Follow-up (not in this PR)

- Cut a new tag (e.g. `v2.0.1`) and bump the pinned SHA in each repo's `release.yml` so consumers actually pick this up (they currently pin `v2.0.0`/`daa4dd1`).
- The live 404 root cause is separate: the org secret `JIRA_WEBHOOK_NEW_RELEASE` points at a stale/invalid Jira Automation hook URL and should be refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvwWiDTsc4b6hGYVMA8eV8